### PR TITLE
Add homework

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,54 +1,47 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
 }
 
-class MyApp extends StatelessWidget {
-  // This widget is the root of your application.
+class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
-      ),
+      title: "My first App",
       home: MyFirstStatefulWidget(),
     );
   }
 }
 
-// int callsCount = 0;
+class MyFirstStatelessWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    Type getContextType() => context.runtimeType;
 
-// class MyFirstStatelessWidget extends StatelessWidget {
-//   @override
-//   Widget build(BuildContext context) {
-//     callsCount++;
+    print(getContextType());
 
-//     print("build called: $callsCount");
-
-//     return Container(
-//       child: Center(
-//         child: Text("Hello!"),
-//       ),
-//     );
-//   }
-// }
+    return Container(
+      child: Center(
+        child: Text("Hello!"),
+      ),
+    );
+  }
+}
 
 class MyFirstStatefulWidget extends StatefulWidget {
+  // Type getContextType() => context.runtimeType;
+
   @override
   _MyFirstStatefulWidgetState createState() => _MyFirstStatefulWidgetState();
 }
 
 class _MyFirstStatefulWidgetState extends State<MyFirstStatefulWidget> {
-  int callsCount = 0;
-
   @override
   Widget build(BuildContext context) {
-    callsCount++;
+    Type getContextType() => context.runtimeType;
 
-    print("build called: $callsCount");
+    print(getContextType());
 
     return Container(
       child: Center(

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:places/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(App());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
1) AS при запуске через play ругается: Entrypoint file not found at path\to\rpoject\lib\main.dart
VSCode не ругается и в принципе даже запускает приложение принудительно через start.dart.
AS также запускает если принудительно выбрать файл и через контекстное меню запустить.
Вывод: framework ожидает конкретное имя начального файла "main.dart".
4) Значение поле title должно отобразиться при нажатии кнопки "recent apps" в диспетчере приложений над снапшотом приложения.
5) Результат: I/flutter (15762): StatelessElement
6) Результат: I/flutter (15762): StatefulElement
Разница в том, что в классе-наследнике StatefulWidget нет контекста, он есть в классе-наследнике State. Если точнее, в данном случае контекст передается в метод build(BuildContext context).
Вывод: контекст доступен только в области его видимости.